### PR TITLE
Fix mobile alignment

### DIFF
--- a/client/e2e/multiplayer-ui.spec.ts
+++ b/client/e2e/multiplayer-ui.spec.ts
@@ -387,12 +387,40 @@ test('round results survive a player refresh', async ({ browser, page, baseURL }
   await joinRoom(guest.page, roomCode, 'Guest');
   await joinRoom(third.page, roomCode, 'Third');
 
+  const connectionDotInsets = await page.locator('.player-item').evaluateAll((items) =>
+    items.map((item) => {
+      const itemRect = item.getBoundingClientRect();
+      const dotRect = item.querySelector('.connection-dot')!.getBoundingClientRect();
+      return itemRect.right - dotRect.right;
+    }),
+  );
+  expect(connectionDotInsets.every((inset) => Math.abs(inset) < 0.1)).toBe(true);
+
   await page.locator('.start-button').click();
   await expect(guest.page.locator('.game-screen')).toBeVisible();
   const finishResponse = await fetch(`${baseURL}/__test__/rooms/${roomCode}/finish-round`, {
     method: 'POST',
   });
   expect(finishResponse.ok).toBe(true);
+
+  await expect(page.locator('.results-reveal-screen')).toBeVisible({ timeout: 6_000 });
+  const countingLayout = await page.locator('.results-reveal-screen').evaluate((screen) => {
+    const screenRect = screen.getBoundingClientRect();
+    const menuRect = screen.querySelector('.results-game-desk')?.getBoundingClientRect();
+    const scoreRect = screen.querySelector('.score-counting')?.getBoundingClientRect();
+    return {
+      screenCenter: screenRect.left + screenRect.width / 2,
+      menuCenter: menuRect ? menuRect.left + menuRect.width / 2 : null,
+      menuBottom: menuRect?.bottom ?? null,
+      scoreCenter: scoreRect ? scoreRect.left + scoreRect.width / 2 : null,
+      scoreTop: scoreRect?.top ?? null,
+    };
+  });
+  expect(countingLayout.menuCenter).not.toBeNull();
+  expect(countingLayout.scoreCenter).not.toBeNull();
+  expect(Math.abs(countingLayout.menuCenter! - countingLayout.screenCenter)).toBeLessThan(1);
+  expect(Math.abs(countingLayout.scoreCenter! - countingLayout.screenCenter)).toBeLessThan(1);
+  expect(countingLayout.menuBottom!).toBeLessThanOrEqual(countingLayout.scoreTop!);
 
   await expect(guest.page.locator('.results-screen')).toBeVisible({ timeout: 8_000 });
   await expect(guest.page.getByText('Host won.')).toBeVisible();

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -923,7 +923,8 @@ button.action-card:hover { background: #e8b85c12; border-color: #e8b85c66; trans
 
 .dealer-badge,
 .dealer-chip { display: inline-grid; place-items: center; color: var(--accent); background: transparent; border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent); font-size: .53rem; font-weight: 500; text-transform: none; }
-.dealer-badge { padding: 4px 7px; border-radius: var(--radius); }
+.dealer-badge { grid-column: 3; padding: 4px 7px; border-radius: var(--radius); }
+.player-item .connection-dot { grid-column: 4; }
 .disconnected .connection-dot { background: var(--red); }
 .waiting-actions { display: flex; padding-top: 20px; justify-content: center; }
 .start-button { min-width: 240px; }
@@ -1339,7 +1340,7 @@ button.action-card:hover { background: #e8b85c12; border-color: #e8b85c66; trans
 @keyframes clock-seat-in { from { opacity: 0; transform: translate(-50%, -45%) scale(.97); } to { opacity: 1; transform: translate(-50%, -50%) scale(1); } }
 
 /* Results */
-.screen.results-reveal-screen { align-items: center; text-align: center; }
+.screen.results-reveal-screen { flex-direction: column; align-items: center; text-align: center; }
 .results-reveal { width: min(100%, 340px); }
 .score-counting {
   display: grid;


### PR DESCRIPTION
## Summary

The lobby now keeps every connection dot at the right edge of its player row. The score counting screen now places the main menu link above the centered status text.

## Root cause

Rows without a dealer badge placed the connection dot in the dealer column. The score screen also used the default horizontal flex direction.

## Checks

- npm run build
- npm run lint
- npx playwright test e2e/multiplayer-ui.spec.ts -g "round results survive"