### PR TITLE
Improve music controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ King's Corner.
   replacing an mp3 means bumping the cache names in `client/public/sw.js`,
   which precaches them.
 - `client/src/music.ts` — optional background music. Six tracks in
-  `client/public/music/` play in order, starting with Shanghai, at 25% volume.
+  `client/public/music/` play in order, starting with Shanghai, at 20% volume
+  by default. Players can change and save the music volume from the sound menu.
   Music has its own saved setting (`badam-satti-background-music`), starts only
   after a player enables it, pauses while the tab is hidden, and continues
   across the waiting room and game screens. The tracks load one at a time and

--- a/client/e2e/multiplayer-ui.spec.ts
+++ b/client/e2e/multiplayer-ui.spec.ts
@@ -306,13 +306,15 @@ test('first-time guide completes the rules and table walkthrough on a phone', as
 
 test('sound settings keep music and game sounds separate from the waiting room into the game', async ({ browser, page, baseURL }) => {
   await login(page, 'Music Host');
-  const roomCode = await createRoom(page);
-
+  await expect(page.getByRole('button', { name: 'How to play' })).toBeVisible();
   await page.getByRole('button', { name: 'Sound settings' }).click();
   const soundMenu = page.getByRole('group', { name: 'Sound settings' });
   const backgroundMusic = soundMenu.getByRole('checkbox', { name: 'Background music' });
+  const musicVolume = soundMenu.getByRole('slider', { name: 'Background music volume' });
   const gameSounds = soundMenu.getByRole('checkbox', { name: 'Game sounds' });
   await expect(backgroundMusic).toHaveAttribute('aria-checked', 'false');
+  await expect(musicVolume).toHaveValue('20');
+  await expect(musicVolume).toBeDisabled();
   await expect(gameSounds).toHaveAttribute('aria-checked', 'true');
   expect(await soundMenu.evaluate((menu) => {
     const rect = menu.getBoundingClientRect();
@@ -322,15 +324,29 @@ test('sound settings keep music and game sounds separate from the waiting room i
   const firstMusicRequest = page.waitForRequest((request) => request.url().endsWith('/music/shanghai.mp3'));
   await backgroundMusic.click();
   await firstMusicRequest;
-  await gameSounds.click();
+  await expect(musicVolume).toBeEnabled();
+  await musicVolume.fill('40');
+  await expect(musicVolume).toHaveValue('40');
+  await expect(soundMenu.getByText('40%', { exact: true })).toBeVisible();
   await expect(backgroundMusic).toHaveAttribute('aria-checked', 'true');
-  await expect(gameSounds).toHaveAttribute('aria-checked', 'false');
+  await expect(gameSounds).toHaveAttribute('aria-checked', 'true');
   expect(await page.evaluate(() => ({
     music: window.localStorage.getItem('badam-satti-background-music'),
+    musicVolume: window.localStorage.getItem('badam-satti-background-music-volume'),
     gameSounds: window.localStorage.getItem('badam-satti-sound'),
-  }))).toEqual({ music: 'on', gameSounds: 'off' });
+  }))).toEqual({ music: 'on', musicVolume: '0.4', gameSounds: null });
   await page.keyboard.press('Escape');
   await expect(soundMenu).not.toBeVisible();
+
+  const roomCode = await createRoom(page);
+  await page.getByRole('button', { name: 'Sound settings' }).click();
+  const waitingSoundMenu = page.getByRole('group', { name: 'Sound settings' });
+  await expect(waitingSoundMenu.getByRole('checkbox', { name: 'Background music' })).toHaveAttribute('aria-checked', 'true');
+  await expect(waitingSoundMenu.getByRole('slider', { name: 'Background music volume' })).toHaveValue('40');
+  const waitingGameSounds = waitingSoundMenu.getByRole('checkbox', { name: 'Game sounds' });
+  await waitingGameSounds.click();
+  await expect(waitingGameSounds).toHaveAttribute('aria-checked', 'false');
+  await page.keyboard.press('Escape');
 
   const guest = await newPlayerPage(browser, {}, baseURL || '');
   const third = await newPlayerPage(browser, {}, baseURL || '');
@@ -342,7 +358,22 @@ test('sound settings keep music and game sounds separate from the waiting room i
   await page.getByRole('button', { name: 'Sound settings' }).click();
   const gameSoundMenu = page.getByRole('group', { name: 'Sound settings' });
   await expect(gameSoundMenu.getByRole('checkbox', { name: 'Background music' })).toHaveAttribute('aria-checked', 'true');
+  await expect(gameSoundMenu.getByRole('slider', { name: 'Background music volume' })).toHaveValue('40');
   await expect(gameSoundMenu.getByRole('checkbox', { name: 'Game sounds' })).toHaveAttribute('aria-checked', 'false');
+  await page.keyboard.press('Escape');
+
+  await page.getByRole('button', { name: 'Leave game' }).click();
+  const leaveDialog = page.getByRole('dialog', { name: 'Leave this game?' });
+  await leaveDialog.getByRole('button', { name: 'Leave game' }).click();
+  await expect(page.locator('.lobby-screen')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'How to play' })).toBeVisible();
+  await page.getByRole('button', { name: 'Sound settings' }).click();
+  const returnedMenu = page.getByRole('group', { name: 'Sound settings' });
+  const returnedMusic = returnedMenu.getByRole('checkbox', { name: 'Background music' });
+  await expect(returnedMusic).toHaveAttribute('aria-checked', 'true');
+  await expect(returnedMenu.getByRole('slider', { name: 'Background music volume' })).toHaveValue('40');
+  await returnedMusic.click();
+  await expect(returnedMusic).toHaveAttribute('aria-checked', 'false');
 
   await guest.context.close();
   await third.context.close();

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1008,6 +1008,8 @@ button.action-card:hover { background: #e8b85c12; border-color: #e8b85c66; trans
   flex: 0 0 auto;
 }
 
+.header-actions .sound-toggle { width: 44px; height: 44px; }
+
 .round-icon-button {
   display: grid;
   width: 34px;
@@ -1063,6 +1065,12 @@ button.action-card:hover { background: #e8b85c12; border-color: #e8b85c66; trans
 }
 .sound-menu-option:hover { background: color-mix(in srgb, var(--accent) 10%, transparent); }
 .sound-menu-option:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.sound-volume { display: grid; gap: 7px; padding: 5px 10px 9px; }
+.sound-volume > span { display: flex; justify-content: space-between; gap: 14px; color: var(--muted); font-size: .63rem; }
+.sound-volume output { color: var(--text); font-variant-numeric: tabular-nums; }
+.sound-volume input { width: 100%; accent-color: var(--accent); cursor: pointer; }
+.sound-volume.is-disabled { opacity: .45; }
+.sound-volume.is-disabled input { cursor: not-allowed; }
 .sound-menu-check {
   display: grid;
   width: 18px;
@@ -2006,6 +2014,14 @@ button.action-card:hover { background: #e8b85c12; border-color: #e8b85c66; trans
 }
 
 @media (max-width: 420px) {
+  .header-actions .sound-menu {
+    position: fixed;
+    top: max(72px, calc(env(safe-area-inset-top) + 58px));
+    right: max(14px, env(safe-area-inset-right));
+    left: max(14px, env(safe-area-inset-left));
+    width: auto;
+    min-width: 0;
+  }
   .game-desk-link { width: auto; justify-content: flex-start; padding-inline: 2px; }
   .game-desk-wordmark { font-size: .54rem; letter-spacing: .08em; }
   .welcome-game-desk { left: 12px; }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,7 @@ import SimulationScreen from './components/SimulationScreen';
 import SummaryScreen from './components/SummaryScreen';
 import WaitingRoom from './components/WaitingRoom';
 import { endAbandonedGame } from './gameAbandonment';
-import { isBackgroundMusicEnabled, resumeBackgroundMusic, setBackgroundMusicEnabled } from './music';
+import { getBackgroundMusicVolume, isBackgroundMusicEnabled, resumeBackgroundMusic, setBackgroundMusicEnabled, setBackgroundMusicVolume } from './music';
 import { NEXT_ROUND_SPLASH_MS, SCORE_COUNTING_SPLASH_MS } from './roundTiming';
 import { isSoundEnabled, playCardSound, playDealSound, playGameWinSound, playKnockSound, playRoundWinSound, setSoundEnabled, unlockAudio } from './sounds';
 import { AppState, Card, ComfortSize, GameSummary, Player, Winner } from './types';
@@ -165,6 +165,7 @@ const App: React.FC = () => {
   const [comfortSize, setComfortSize] = useState<ComfortSize>(getInitialComfortSize);
   const [soundOn, setSoundOn] = useState<boolean>(isSoundEnabled);
   const [backgroundMusicOn, setBackgroundMusicOn] = useState<boolean>(isBackgroundMusicEnabled);
+  const [backgroundMusicVolume, setBackgroundMusicVolumeState] = useState<number>(getBackgroundMusicVolume);
 
   useEffect(() => {
     document.documentElement.dataset.comfortSize = comfortSize;
@@ -200,6 +201,11 @@ const App: React.FC = () => {
     setBackgroundMusicOn(value);
   };
 
+  const changeBackgroundMusicVolume = (value: number) => {
+    setBackgroundMusicVolume(value);
+    setBackgroundMusicVolumeState(value);
+  };
+
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
@@ -214,7 +220,9 @@ const App: React.FC = () => {
               soundOn={soundOn}
               onSoundChange={changeSound}
               backgroundMusicOn={backgroundMusicOn}
+              backgroundMusicVolume={backgroundMusicVolume}
               onBackgroundMusicChange={changeBackgroundMusic}
+              onBackgroundMusicVolumeChange={changeBackgroundMusicVolume}
             />
           )}
         />
@@ -269,7 +277,9 @@ interface MainAppProps {
   soundOn: boolean;
   onSoundChange: (value: boolean) => void;
   backgroundMusicOn: boolean;
+  backgroundMusicVolume: number;
   onBackgroundMusicChange: (value: boolean) => void;
+  onBackgroundMusicVolumeChange: (value: number) => void;
 }
 
 const MainApp: React.FC<MainAppProps> = ({
@@ -278,7 +288,9 @@ const MainApp: React.FC<MainAppProps> = ({
   soundOn,
   onSoundChange,
   backgroundMusicOn,
+  backgroundMusicVolume,
   onBackgroundMusicChange,
+  onBackgroundMusicVolumeChange,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -875,11 +887,11 @@ const MainApp: React.FC<MainAppProps> = ({
       case 'login':
         return <LoginScreen onContinue={(username) => setAppState((previous) => ({ ...previous, username, currentScreen: 'menu' }))} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} />;
       case 'menu':
-        return <MenuScreen username={appState.username} onCreateRoom={createRoom} onJoinRoom={joinRoom} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} />;
+        return <MenuScreen username={appState.username} onCreateRoom={createRoom} onJoinRoom={joinRoom} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} backgroundMusicVolume={backgroundMusicVolume} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange} onGameSoundsChange={onSoundChange} />;
       case 'waiting':
-        return <WaitingRoom roomCode={appState.currentRoom} gameState={appState.gameState} username={appState.username} gameEndedByDepartures={appState.gameEndedByDepartures} onStartGame={startGame} onLeaveRoom={leaveRoom} onShowNotification={notify} onReturnToGameDesk={leaveRoomForGameDesk} onSetTurnDuration={setTurnDuration} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onGameSoundsChange={onSoundChange} />;
+        return <WaitingRoom roomCode={appState.currentRoom} gameState={appState.gameState} username={appState.username} gameEndedByDepartures={appState.gameEndedByDepartures} onStartGame={startGame} onLeaveRoom={leaveRoom} onShowNotification={notify} onReturnToGameDesk={leaveRoomForGameDesk} onSetTurnDuration={setTurnDuration} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} backgroundMusicVolume={backgroundMusicVolume} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange} onGameSoundsChange={onSoundChange} />;
       case 'game':
-        return <GameScreen gameState={appState.gameState} myCards={appState.myCards} validMoves={appState.validMoves} isMyTurn={appState.isMyTurn} canPass={appState.canPass} username={appState.username} onPlayCard={playCard} onPassTurn={passTurn} onLeaveGame={leaveRoom} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onGameSoundsChange={onSoundChange} onReturnToGameDesk={leaveRoomForGameDesk} roundWinnerName={appState.gameState?.gameFinished ? appState.winner?.winner : undefined} />;
+        return <GameScreen gameState={appState.gameState} myCards={appState.myCards} validMoves={appState.validMoves} isMyTurn={appState.isMyTurn} canPass={appState.canPass} username={appState.username} onPlayCard={playCard} onPassTurn={passTurn} onLeaveGame={leaveRoom} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} backgroundMusicVolume={backgroundMusicVolume} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange} onGameSoundsChange={onSoundChange} onReturnToGameDesk={leaveRoomForGameDesk} roundWinnerName={appState.gameState?.gameFinished ? appState.winner?.winner : undefined} />;
       case 'game-over':
         return <GameOverScreen winner={appState.winner} username={appState.username} onContinueRound={() => { showLoading('Starting next round…'); socketRef.current?.emit('continue_round'); }} onExitGame={() => { showLoading('Calculating results…'); socketRef.current?.emit('exit_game'); }} showingDelay={showingGameOverDelay} canContinueRound={Boolean(hasMinimumPlayers && appState.gameState && appState.gameState.round < appState.gameState.maxRounds)} hasMinimumPlayers={hasMinimumPlayers} canFinishGame={canFinishGame} onReturnToGameDesk={leaveRoomForGameDesk} />;
       case 'round-start':

--- a/client/src/components/GameScreen.tsx
+++ b/client/src/components/GameScreen.tsx
@@ -18,8 +18,10 @@ interface GameScreenProps {
   comfortSize: ComfortSize;
   onComfortSizeChange: (size: ComfortSize) => void;
   backgroundMusicOn: boolean;
+  backgroundMusicVolume: number;
   gameSoundsOn: boolean;
   onBackgroundMusicChange: (value: boolean) => void;
+  onBackgroundMusicVolumeChange: (value: number) => void;
   onGameSoundsChange: (value: boolean) => void;
   onReturnToGameDesk: () => Promise<void>;
   roundWinnerName?: string;
@@ -47,8 +49,10 @@ const GameScreen: React.FC<GameScreenProps> = ({
   comfortSize,
   onComfortSizeChange,
   backgroundMusicOn,
+  backgroundMusicVolume,
   gameSoundsOn,
   onBackgroundMusicChange,
+  onBackgroundMusicVolumeChange,
   onGameSoundsChange,
   onReturnToGameDesk,
   roundWinnerName,
@@ -399,8 +403,10 @@ const GameScreen: React.FC<GameScreenProps> = ({
           <div className="game-toolbar">
             <SoundToggle
               backgroundMusicOn={backgroundMusicOn}
+              backgroundMusicVolume={backgroundMusicVolume}
               gameSoundsOn={gameSoundsOn}
               onBackgroundMusicChange={onBackgroundMusicChange}
+              onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange}
               onGameSoundsChange={onGameSoundsChange}
             />
             <button className="round-icon-button" onClick={() => setShowHelp(true)} aria-label="How to play">?</button>

--- a/client/src/components/MenuScreen.tsx
+++ b/client/src/components/MenuScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import HelpModal from './HelpModal';
 import { ComfortSize } from '../types';
 import GameDeskLink from './GameDeskLink';
+import SoundToggle from './SoundToggle';
 
 interface MenuScreenProps {
   username: string;
@@ -9,6 +10,12 @@ interface MenuScreenProps {
   onJoinRoom: (roomCode: string) => void;
   comfortSize: ComfortSize;
   onComfortSizeChange: (size: ComfortSize) => void;
+  backgroundMusicOn: boolean;
+  backgroundMusicVolume: number;
+  gameSoundsOn: boolean;
+  onBackgroundMusicChange: (value: boolean) => void;
+  onBackgroundMusicVolumeChange: (value: number) => void;
+  onGameSoundsChange: (value: boolean) => void;
 }
 
 const LOBBY_GREETINGS = [
@@ -27,7 +34,19 @@ const LobbyGreeting: React.FC<{ username: string }> = ({ username }) => {
   return <h2>{greeting.lead}, <span>{username}</span>{greeting.punctuation}</h2>;
 };
 
-const MenuScreen: React.FC<MenuScreenProps> = ({ username, onCreateRoom, onJoinRoom, comfortSize, onComfortSizeChange }) => {
+const MenuScreen: React.FC<MenuScreenProps> = ({
+  username,
+  onCreateRoom,
+  onJoinRoom,
+  comfortSize,
+  onComfortSizeChange,
+  backgroundMusicOn,
+  backgroundMusicVolume,
+  gameSoundsOn,
+  onBackgroundMusicChange,
+  onBackgroundMusicVolumeChange,
+  onGameSoundsChange,
+}) => {
   const [roomCode, setRoomCode] = useState('');
   const [showHelpModal, setShowHelpModal] = useState(false);
 
@@ -56,6 +75,14 @@ const MenuScreen: React.FC<MenuScreenProps> = ({ username, onCreateRoom, onJoinR
         <header className="app-header">
           <GameDeskLink />
           <div className="header-actions">
+            <SoundToggle
+              backgroundMusicOn={backgroundMusicOn}
+              backgroundMusicVolume={backgroundMusicVolume}
+              gameSoundsOn={gameSoundsOn}
+              onBackgroundMusicChange={onBackgroundMusicChange}
+              onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange}
+              onGameSoundsChange={onGameSoundsChange}
+            />
             <button className="quiet-button" onClick={() => setShowHelpModal(true)}>How to play</button>
             <button
               className="text-size-button menu-text-size-button"

--- a/client/src/components/SoundToggle.tsx
+++ b/client/src/components/SoundToggle.tsx
@@ -2,8 +2,10 @@ import React, { useEffect, useId, useRef, useState } from 'react';
 
 interface SoundToggleProps {
   backgroundMusicOn: boolean;
+  backgroundMusicVolume: number;
   gameSoundsOn: boolean;
   onBackgroundMusicChange: (value: boolean) => void;
+  onBackgroundMusicVolumeChange: (value: number) => void;
   onGameSoundsChange: (value: boolean) => void;
 }
 
@@ -23,8 +25,10 @@ const SoundIcon: React.FC<{ on: boolean }> = ({ on }) => (
 
 const SoundToggle: React.FC<SoundToggleProps> = ({
   backgroundMusicOn,
+  backgroundMusicVolume,
   gameSoundsOn,
   onBackgroundMusicChange,
+  onBackgroundMusicVolumeChange,
   onGameSoundsChange,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -74,6 +78,22 @@ const SoundToggle: React.FC<SoundToggleProps> = ({
             </span>
             <span>Background music</span>
           </button>
+          <label className={`sound-volume ${backgroundMusicOn ? '' : 'is-disabled'}`}>
+            <span>
+              Music volume
+              <output>{Math.round(backgroundMusicVolume * 100)}%</output>
+            </span>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              step="5"
+              value={Math.round(backgroundMusicVolume * 100)}
+              disabled={!backgroundMusicOn}
+              aria-label="Background music volume"
+              onChange={(event) => onBackgroundMusicVolumeChange(Number(event.target.value) / 100)}
+            />
+          </label>
           <button
             className="sound-menu-option"
             role="checkbox"

--- a/client/src/components/WaitingRoom.tsx
+++ b/client/src/components/WaitingRoom.tsx
@@ -17,8 +17,10 @@ interface WaitingRoomProps {
   comfortSize: ComfortSize;
   onComfortSizeChange: (size: ComfortSize) => void;
   backgroundMusicOn: boolean;
+  backgroundMusicVolume: number;
   gameSoundsOn: boolean;
   onBackgroundMusicChange: (value: boolean) => void;
+  onBackgroundMusicVolumeChange: (value: number) => void;
   onGameSoundsChange: (value: boolean) => void;
 }
 
@@ -37,8 +39,10 @@ const WaitingRoom: React.FC<WaitingRoomProps> = ({
   comfortSize,
   onComfortSizeChange,
   backgroundMusicOn,
+  backgroundMusicVolume,
   gameSoundsOn,
   onBackgroundMusicChange,
+  onBackgroundMusicVolumeChange,
   onGameSoundsChange,
 }) => {
   const [lanOrigin, setLanOrigin] = useState<string | null>(null);
@@ -83,8 +87,10 @@ const WaitingRoom: React.FC<WaitingRoomProps> = ({
           <div className="waiting-toolbar">
             <SoundToggle
               backgroundMusicOn={backgroundMusicOn}
+              backgroundMusicVolume={backgroundMusicVolume}
               gameSoundsOn={gameSoundsOn}
               onBackgroundMusicChange={onBackgroundMusicChange}
+              onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange}
               onGameSoundsChange={onGameSoundsChange}
             />
             <button className="round-icon-button" onClick={() => setShowHelp(true)} aria-label="How to play">?</button>

--- a/client/src/music.ts
+++ b/client/src/music.ts
@@ -1,5 +1,6 @@
 const MUSIC_STORAGE_KEY = 'badam-satti-background-music';
-const BACKGROUND_MUSIC_VOLUME = 0.25;
+const MUSIC_VOLUME_STORAGE_KEY = 'badam-satti-background-music-volume';
+const DEFAULT_BACKGROUND_MUSIC_VOLUME = 0.2;
 
 const BACKGROUND_TRACKS = [
   'shanghai.mp3',
@@ -11,6 +12,7 @@ const BACKGROUND_TRACKS = [
 ];
 
 let enabled = readStoredPreference();
+let volume = readStoredVolume();
 let player: HTMLAudioElement | null = null;
 let trackIndex = 0;
 let failedTrackCount = 0;
@@ -22,6 +24,23 @@ function readStoredPreference(): boolean {
   } catch {
     return false;
   }
+}
+
+function readStoredVolume(): number {
+  try {
+    const storedValue = window.localStorage.getItem(MUSIC_VOLUME_STORAGE_KEY);
+    if (storedValue === null) return DEFAULT_BACKGROUND_MUSIC_VOLUME;
+    const storedVolume = Number(storedValue);
+    return Number.isFinite(storedVolume) && storedVolume >= 0 && storedVolume <= 1
+      ? storedVolume
+      : DEFAULT_BACKGROUND_MUSIC_VOLUME;
+  } catch {
+    return DEFAULT_BACKGROUND_MUSIC_VOLUME;
+  }
+}
+
+function clampVolume(value: number): number {
+  return Math.min(1, Math.max(0, value));
 }
 
 function trackUrl(index: number): string {
@@ -52,7 +71,7 @@ function getPlayer(): HTMLAudioElement {
   if (player) return player;
 
   player = new Audio();
-  player.volume = BACKGROUND_MUSIC_VOLUME;
+  player.volume = volume;
   player.preload = 'auto';
   player.addEventListener('playing', () => {
     failedTrackCount = 0;
@@ -90,6 +109,20 @@ export function setBackgroundMusicEnabled(value: boolean) {
 
   if (value) playCurrentTrack();
   else player?.pause();
+}
+
+export function getBackgroundMusicVolume(): number {
+  return volume;
+}
+
+export function setBackgroundMusicVolume(value: number) {
+  volume = clampVolume(value);
+  if (player) player.volume = volume;
+  try {
+    window.localStorage.setItem(MUSIC_VOLUME_STORAGE_KEY, String(volume));
+  } catch {
+    // The level still applies for this session when storage is unavailable.
+  }
 }
 
 export function resumeBackgroundMusic() {


### PR DESCRIPTION
## What changed

Added sound settings to the main menu beside How to play. Background music now starts at 20% volume, and players can change the level from 0% to 100% in 5% steps. The level is saved across screens and future visits.

The narrow phone sound menu now stays inside the viewport.

## Why

Background music continued after a game ended, but the main menu had no sound control. Players had to mute their device to stop it.

## Validation

* Client build passed.
* Client tests passed.
* ESLint passed.
* The focused Playwright flow passed on a 320 px phone, current phone, phone landscape, and desktop zoom. It enables music, changes the volume, enters a game, leaves, returns to the menu, and turns music off.