### PR TITLE
Fix stale room recovery across tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ validMoves, canPass})`, `card_played({playerName, card, gameState, automatic?})`
 `turn_duration_changed({turnDurationSeconds, gameState})`, `game_over(winner)`,
 `round_continued({gameState})`, `cards_redistributed({message})`,
 `not_enough_players({message, gameState})`, `game_totals`, `left_room`,
-`game_state`, and `error` (string or
+`game_state`, `game_abandoned({message, recoveryFailure?})`, and `error` (string or
 `{code, message}`; codes include `ROOM_NOT_FOUND`, `USERNAME_TAKEN`,
 `GAME_ALREADY_STARTED`, `HOST_ONLY`, `NOT_ENOUGH_CONNECTED_PLAYERS`,
 `PLAYERS_RECONNECTING`, `RECONNECT_REQUIRED`, `RECONNECT_UNAVAILABLE`).
@@ -121,6 +121,10 @@ late caller into the already-started round instead of erroring.
 - Rooms are persisted to SQLite on every state change and on shutdown;
   `ensureRoomExists` restores a room from the DB on demand and starts a fresh
   turn timer if a round is active. Socket.io: 120s ping timeout, 30s interval.
+- Each browser tab keeps its active room in `sessionStorage`. Saved recovery
+  records are kept per room in `localStorage`, so one tab cannot replace or
+  clear another tab's room. Returning tabs check the server state. An ended
+  room returns to the menu without requiring an explicit Leave action.
 
 ## Security / infra notes
 

--- a/client/e2e/multiplayer-ui.spec.ts
+++ b/client/e2e/multiplayer-ui.spec.ts
@@ -379,7 +379,7 @@ test('sound settings keep music and game sounds separate from the waiting room i
   await third.context.close();
 });
 
-test('room session survives waiting and active-game refreshes with a safe recovery exit', async ({ browser, page, baseURL }, testInfo) => {
+test('room session survives waiting and active-game refreshes and clears an ended room', async ({ browser, page, baseURL }, testInfo) => {
   const projectUse = testInfo.project.use as BrowserContextOptions;
   const contextOptions: BrowserContextOptions = {
     viewport: page.viewportSize() || projectUse.viewport || { width: 1280, height: 720 },
@@ -433,17 +433,61 @@ test('room session survives waiting and active-game refreshes with a safe recove
   });
   await missingRoom.page.goto('/badam7/');
 
-  const recoveryDialog = missingRoom.page.getByRole('alertdialog');
-  await expect(recoveryDialog).toContainText('Your saved seat is no longer available.');
-  await expect(recoveryDialog.getByRole('button', { name: 'Reconnect to room' })).toBeVisible();
-  await recoveryDialog.getByRole('button', { name: 'Leave room' }).click();
   await expect(missingRoom.page.locator('.lobby-screen')).toBeVisible();
+  await expect(missingRoom.page.getByRole('alertdialog')).toHaveCount(0);
+  await missingRoom.page.getByRole('button', { name: 'Continue room ZZZZZZ' }).click();
+  await expect(missingRoom.page.getByRole('status')).toContainText('This game has ended.');
   expect(await missingRoom.page.evaluate(() => window.localStorage.getItem('badam-satti-room-session'))).toBeNull();
+  expect(await missingRoom.page.evaluate(() => window.sessionStorage.getItem('badam-satti-tab-room-session-v2'))).toBeNull();
 
   await guest.context.close();
   await third.context.close();
   await secondHost.context.close();
   await missingRoom.context.close();
+});
+
+test('different tabs keep different rooms and an ended old tab cannot clear the new game', async ({ browser, page, baseURL }) => {
+  await login(page, 'First Host');
+  const firstRoomCode = await createRoom(page);
+
+  const secondHost = await newPlayerPage(browser, {}, baseURL || '');
+  await login(secondHost.page, 'Second Host');
+  const secondRoomCode = await createRoom(secondHost.page);
+
+  const secondTab = await page.context().newPage();
+  await joinRoom(secondTab, secondRoomCode, 'Second Tab');
+  await expect(secondTab.locator('.invite-copy strong')).toHaveText(secondRoomCode);
+
+  await page.bringToFront();
+  await page.reload();
+  await expect(page.locator('.waiting-screen')).toBeVisible();
+  await expect(page.locator('.invite-copy strong')).toHaveText(firstRoomCode);
+
+  await secondTab.bringToFront();
+  await secondTab.reload();
+  await expect(secondTab.locator('.waiting-screen')).toBeVisible();
+  await expect(secondTab.locator('.invite-copy strong')).toHaveText(secondRoomCode);
+
+  const staleTab = await page.context().newPage();
+  await staleTab.addInitScript(() => {
+    window.sessionStorage.setItem('badam-satti-tab-room-session-v2', JSON.stringify({
+      roomCode: 'ZZZZZZ',
+      username: 'Old Tab',
+      sessionToken: '00000000-0000-4000-8000-000000000000',
+    }));
+  });
+  await staleTab.goto('/badam7/');
+  await expect(staleTab.locator('.lobby-screen')).toBeVisible();
+  await expect(staleTab.getByRole('alertdialog')).toHaveCount(0);
+  await expect(staleTab.getByRole('status')).toContainText('This game has ended.');
+
+  await secondTab.reload();
+  await expect(secondTab.locator('.waiting-screen')).toBeVisible();
+  await expect(secondTab.locator('.invite-copy strong')).toHaveText(secondRoomCode);
+
+  await staleTab.close();
+  await secondTab.close();
+  await secondHost.context.close();
 });
 
 test('round results survive a player refresh', async ({ browser, page, baseURL }, testInfo) => {

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,4 +1,4 @@
-const APP_CACHE = 'badam-satti-app-v16';
+const APP_CACHE = 'badam-satti-app-v17';
 const CARD_CACHE = 'badam-satti-cards-v15';
 const APP_ROOT = '/badam7/';
 const APP_SHELL = [

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -495,6 +495,8 @@ input::placeholder { color: var(--faint); }
   line-height: 1.6;
 }
 
+.saved-room-button { margin-top: 16px; }
+
 .menu-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
 
 .action-card {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,8 @@ import WaitingRoom from './components/WaitingRoom';
 import { endAbandonedGame } from './gameAbandonment';
 import { getBackgroundMusicVolume, isBackgroundMusicEnabled, resumeBackgroundMusic, setBackgroundMusicEnabled, setBackgroundMusicVolume } from './music';
 import { NEXT_ROUND_SPLASH_MS, SCORE_COUNTING_SPLASH_MS } from './roundTiming';
+import { clearRoomSession, findSavedRoomSession, findSavedRoomSessionForRoom, loadMostRecentSavedRoomSession, loadTabRoomSession, saveRoomSession } from './roomSession';
+import type { RoomSession } from './roomSession';
 import { isSoundEnabled, playCardSound, playDealSound, playGameWinSound, playKnockSound, playRoundWinSound, setSoundEnabled, unlockAudio } from './sounds';
 import { AppState, Card, ComfortSize, GameSummary, Player, Winner } from './types';
 
@@ -37,14 +39,7 @@ interface ServerErrorPayload {
   message?: string;
 }
 
-interface RoomSession {
-  roomCode: string;
-  username: string;
-  sessionToken: string;
-}
-
 const COMFORT_SIZE_STORAGE_KEY = 'badam-satti-comfort-size';
-const ROOM_SESSION_STORAGE_KEY = 'badam-satti-room-session';
 const COMFORT_SIZES: ComfortSize[] = ['standard', 'large', 'extra-large', 'maximum'];
 
 const createEmptyAppState = (): AppState => ({
@@ -65,50 +60,18 @@ const createEmptyAppState = (): AppState => ({
   gameEndedByDepartures: false,
 });
 
-
-function loadRoomSession(): RoomSession | null {
-  try {
-    const parsed = JSON.parse(window.localStorage.getItem(ROOM_SESSION_STORAGE_KEY) || 'null');
-    if (
-      parsed &&
-      typeof parsed.username === 'string' &&
-      parsed.username.trim().length > 0 &&
-      typeof parsed.roomCode === 'string' &&
-      /^[A-Z0-9]{6}$/.test(parsed.roomCode) &&
-      typeof parsed.sessionToken === 'string' &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(parsed.sessionToken)
-    ) {
-      return {
-        username: parsed.username,
-        roomCode: parsed.roomCode,
-        sessionToken: parsed.sessionToken,
-      };
-    }
-  } catch {
-    // Invalid or unavailable storage should not prevent the app from opening.
-  }
-  return null;
-}
-
-function saveRoomSession(session: RoomSession) {
-  try {
-    window.localStorage.setItem(ROOM_SESSION_STORAGE_KEY, JSON.stringify(session));
-  } catch {
-    // The live in-memory session still works when storage is unavailable.
-  }
-}
-
-function clearRoomSession() {
-  try {
-    window.localStorage.removeItem(ROOM_SESSION_STORAGE_KEY);
-  } catch {
-    // The live in-memory session can still be cleared.
-  }
-}
-
 function getInitialAppState(): AppState {
-  const session = loadRoomSession();
-  if (!session) return createEmptyAppState();
+  const session = loadTabRoomSession();
+  if (!session) {
+    const savedSession = loadMostRecentSavedRoomSession();
+    return savedSession
+      ? {
+          ...createEmptyAppState(),
+          username: savedSession.username,
+          currentScreen: 'menu',
+        }
+      : createEmptyAppState();
+  }
 
   return {
     ...createEmptyAppState(),
@@ -236,7 +199,7 @@ const JoinRoomRoute: React.FC = () => {
   const navigate = useNavigate();
   const routeLocation = useLocation();
   const routeState = routeLocation.state as RouteState | null;
-  const savedSession = loadRoomSession();
+  const savedSession = roomCode ? findSavedRoomSessionForRoom(roomCode) : null;
 
   if (!roomCode) return <div>Invalid room code</div>;
 
@@ -245,20 +208,14 @@ const JoinRoomRoute: React.FC = () => {
       <JoinRoomScreen
         roomCode={roomCode.toUpperCase()}
         onJoinRoom={(code, username) => {
-          const sessionToken =
-            savedSession?.roomCode === code &&
-            savedSession.username === username
-              ? savedSession.sessionToken
-              : undefined;
+          const sessionToken = findSavedRoomSession(code, username)?.sessionToken;
           navigate(`/${routeLocation.search}`, {
             state: { joinRoom: { roomCode: code, username, sessionToken } },
           });
         }}
         onBackToMenu={() => navigate('/')}
         error={routeState?.error || null}
-        initialUsername={routeState?.username || (
-          savedSession?.roomCode === roomCode.toUpperCase() ? savedSession.username : ''
-        )}
+        initialUsername={routeState?.username || savedSession?.username || ''}
         onClearError={() => navigate(`/r/${roomCode}`, { replace: true })}
       />
     </div>
@@ -308,6 +265,9 @@ const MainApp: React.FC<MainAppProps> = ({
   const [isConnected, setIsConnected] = useState(false);
   const [showingGameOverDelay, setShowingGameOverDelay] = useState(false);
   const [recoverySession, setRecoverySession] = useState<RoomSession | null>(null);
+  const [savedRoomSession, setSavedRoomSession] = useState<RoomSession | null>(() => (
+    initialJoinRequest ? null : loadMostRecentSavedRoomSession()
+  ));
   const socketRef = useRef<Socket | null>(null);
   const stateRef = useRef(appState);
   const joinRequestRef = useRef<JoinRequest | null>(null);
@@ -398,6 +358,7 @@ const MainApp: React.FC<MainAppProps> = ({
     socket.on('room_created', ({ roomCode, sessionToken, gameState }) => {
       saveRoomSession({ roomCode, username: stateRef.current.username, sessionToken });
       setRecoverySession(null);
+      setSavedRoomSession(null);
       setAppState((previous) => ({
         ...previous,
         currentRoom: roomCode,
@@ -415,6 +376,7 @@ const MainApp: React.FC<MainAppProps> = ({
       joinRequestRef.current = null;
       saveRoomSession({ roomCode, username, sessionToken });
       setRecoverySession(null);
+      setSavedRoomSession(null);
       setAppState((previous) => ({
         ...previous,
         currentRoom: roomCode,
@@ -457,6 +419,7 @@ const MainApp: React.FC<MainAppProps> = ({
       joinRequestRef.current = null;
       saveRoomSession({ roomCode, username, sessionToken });
       setRecoverySession(null);
+      setSavedRoomSession(null);
       setShowingGameOverDelay(false);
       setAppState((previous) => ({
         ...previous,
@@ -526,12 +489,14 @@ const MainApp: React.FC<MainAppProps> = ({
       }, 2500);
     });
 
-    socket.on('game_abandoned', ({ message }: { message: string }) => {
+    socket.on('game_abandoned', ({ message, recoveryFailure }: { message: string; recoveryFailure?: boolean }) => {
+      if (recoveryFailure && joinRequestRef.current && !joinRequestRef.current.sessionToken) return;
       actionPendingRef.current = false;
       reconnectPendingRef.current = false;
       clearRoundStart();
       clearRoomSession();
       setRecoverySession(null);
+      setSavedRoomSession(null);
       setShowingGameOverDelay(false);
       if (resultTimer.current !== null) window.clearTimeout(resultTimer.current);
       if (finalPlayTimer.current !== null) window.clearTimeout(finalPlayTimer.current);
@@ -614,6 +579,7 @@ const MainApp: React.FC<MainAppProps> = ({
 
     socket.on('game_state', (playerState) => {
       if (!playerState) return;
+      reconnectPendingRef.current = false;
       const gameState = playerState.gameState || playerState;
       setAppState((previous) => ({
         ...previous,
@@ -625,16 +591,73 @@ const MainApp: React.FC<MainAppProps> = ({
         currentScreen: previous.currentScreen === 'round-start'
           ? 'round-start'
           : screenForGameState(gameState),
+        loading: null,
+        error: null,
       }));
     });
 
     socket.on('error', (message: string | Error | ServerErrorPayload) => {
       actionPendingRef.current = false;
       const errorMessage = getServerErrorMessage(message);
+      const errorCode = typeof message === 'object' && !(message instanceof Error) ? message.code : undefined;
+      const current = stateRef.current;
+      const recoveryEnded =
+        (errorCode === 'ROOM_NOT_FOUND' || errorCode === 'RECONNECT_UNAVAILABLE') &&
+        Boolean(current.currentRoom && current.username && current.sessionToken);
+
+      if (recoveryEnded) {
+        reconnectPendingRef.current = false;
+        setRecoverySession(null);
+        setSavedRoomSession(null);
+        clearRoomSession({
+          roomCode: current.currentRoom,
+          username: current.username,
+          sessionToken: current.sessionToken,
+        });
+
+        const pendingJoin = joinRequestRef.current;
+        if (pendingJoin?.sessionToken && errorCode === 'RECONNECT_UNAVAILABLE') {
+          const freshJoin = { roomCode: pendingJoin.roomCode, username: pendingJoin.username };
+          joinRequestRef.current = freshJoin;
+          setAppState((previous) => ({
+            ...previous,
+            currentRoom: '',
+            sessionToken: '',
+            currentScreen: 'loading',
+            loading: 'Joining room…',
+            error: null,
+          }));
+          socket.emit('join_room', freshJoin);
+          return;
+        }
+
+        if (pendingJoin) {
+          joinRequestRef.current = null;
+          setAppState((previous) => ({
+            ...previous,
+            currentRoom: '',
+            sessionToken: '',
+            gameState: null,
+            loading: null,
+            error: null,
+          }));
+          navigate(`/r/${pendingJoin.roomCode}`, {
+            state: { error: errorMessage, username: pendingJoin.username },
+            replace: true,
+          });
+          return;
+        }
+
+        const endedMessage = errorCode === 'ROOM_NOT_FOUND'
+          ? 'This game has ended.'
+          : 'Your seat in this game has expired.';
+        setAppState((previous) => endAbandonedGame(previous, endedMessage));
+        navigate('/', { replace: true });
+        return;
+      }
+
       if (reconnectPendingRef.current) {
         reconnectPendingRef.current = false;
-        const errorCode = typeof message === 'object' && !(message instanceof Error) ? message.code : undefined;
-        const current = stateRef.current;
         if (current.currentRoom && current.username) {
           setRecoverySession({
             roomCode: current.currentRoom,
@@ -790,6 +813,26 @@ const MainApp: React.FC<MainAppProps> = ({
     socket.emit('create_room', appState.username);
   }
 
+  function continueSavedRoom() {
+    const session = savedRoomSession;
+    const socket = requireConnection();
+    if (!session || !socket) return;
+
+    saveRoomSession(session);
+    reconnectPendingRef.current = true;
+    setSavedRoomSession(null);
+    setAppState((previous) => ({
+      ...previous,
+      username: session.username,
+      currentRoom: session.roomCode,
+      sessionToken: session.sessionToken,
+      currentScreen: 'loading',
+      loading: 'Checking your saved game…',
+      error: null,
+    }));
+    socket.emit('reconnect_to_room', session);
+  }
+
   function joinRoom(roomCode: string, username = appState.username) {
     const socket = requireConnection();
     if (!socket || !username) return;
@@ -887,7 +930,7 @@ const MainApp: React.FC<MainAppProps> = ({
       case 'login':
         return <LoginScreen onContinue={(username) => setAppState((previous) => ({ ...previous, username, currentScreen: 'menu' }))} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} />;
       case 'menu':
-        return <MenuScreen username={appState.username} onCreateRoom={createRoom} onJoinRoom={joinRoom} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} backgroundMusicVolume={backgroundMusicVolume} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange} onGameSoundsChange={onSoundChange} />;
+        return <MenuScreen username={appState.username} onCreateRoom={createRoom} onJoinRoom={joinRoom} savedRoomCode={savedRoomSession?.roomCode} onContinueRoom={savedRoomSession ? continueSavedRoom : undefined} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} backgroundMusicVolume={backgroundMusicVolume} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange} onGameSoundsChange={onSoundChange} />;
       case 'waiting':
         return <WaitingRoom roomCode={appState.currentRoom} gameState={appState.gameState} username={appState.username} gameEndedByDepartures={appState.gameEndedByDepartures} onStartGame={startGame} onLeaveRoom={leaveRoom} onShowNotification={notify} onReturnToGameDesk={leaveRoomForGameDesk} onSetTurnDuration={setTurnDuration} comfortSize={comfortSize} onComfortSizeChange={onComfortSizeChange} backgroundMusicOn={backgroundMusicOn} backgroundMusicVolume={backgroundMusicVolume} gameSoundsOn={soundOn} onBackgroundMusicChange={onBackgroundMusicChange} onBackgroundMusicVolumeChange={onBackgroundMusicVolumeChange} onGameSoundsChange={onSoundChange} />;
       case 'game':

--- a/client/src/components/MenuScreen.tsx
+++ b/client/src/components/MenuScreen.tsx
@@ -8,6 +8,8 @@ interface MenuScreenProps {
   username: string;
   onCreateRoom: () => void;
   onJoinRoom: (roomCode: string) => void;
+  savedRoomCode?: string;
+  onContinueRoom?: () => void;
   comfortSize: ComfortSize;
   onComfortSizeChange: (size: ComfortSize) => void;
   backgroundMusicOn: boolean;
@@ -38,6 +40,8 @@ const MenuScreen: React.FC<MenuScreenProps> = ({
   username,
   onCreateRoom,
   onJoinRoom,
+  savedRoomCode,
+  onContinueRoom,
   comfortSize,
   onComfortSizeChange,
   backgroundMusicOn,
@@ -98,6 +102,11 @@ const MenuScreen: React.FC<MenuScreenProps> = ({
           <span className="eyebrow game-lobby-label"><b aria-hidden="true">7♥</b> Badam 7 table</span>
           <LobbyGreeting username={username} />
           <p>Choose one: host a new room, or join using a code someone sent you.</p>
+          {savedRoomCode && onContinueRoom && (
+            <button className="quiet-button saved-room-button" onClick={onContinueRoom}>
+              Continue room {savedRoomCode}
+            </button>
+          )}
         </section>
 
         <div className="menu-grid">

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,6 +5,14 @@ import App from './App.tsx'
 import './index.css'
 
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  const hadServiceWorkerController = Boolean(navigator.serviceWorker.controller)
+  let reloadingForUpdate = false
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!hadServiceWorkerController || reloadingForUpdate) return
+    reloadingForUpdate = true
+    window.location.reload()
+  })
+
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`, { scope: import.meta.env.BASE_URL })
       .then((registration) => {

--- a/client/src/roomSession.d.ts
+++ b/client/src/roomSession.d.ts
@@ -1,0 +1,41 @@
+export interface RoomSession {
+  roomCode: string;
+  username: string;
+  sessionToken: string;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export function loadTabRoomSession(sessionStorage?: StorageLike): RoomSession | null;
+export function loadMostRecentSavedRoomSession(localStorage?: StorageLike): RoomSession | null;
+export function findSavedRoomSession(
+  roomCode: string,
+  username: string,
+  sessionStorage?: StorageLike,
+  localStorage?: StorageLike,
+): RoomSession | null;
+export function findSavedRoomSessionForRoom(
+  roomCode: string,
+  sessionStorage?: StorageLike,
+  localStorage?: StorageLike,
+): RoomSession | null;
+export function saveRoomSession(
+  value: RoomSession,
+  sessionStorage?: StorageLike,
+  localStorage?: StorageLike,
+  now?: number,
+): void;
+export function clearRoomSession(
+  value?: RoomSession | null,
+  sessionStorage?: StorageLike,
+  localStorage?: StorageLike,
+): void;
+export const roomSessionStorageKeys: {
+  legacy: string;
+  tab: string;
+  saved: string;
+};

--- a/client/src/roomSession.js
+++ b/client/src/roomSession.js
@@ -1,0 +1,190 @@
+const LEGACY_ROOM_SESSION_KEY = 'badam-satti-room-session';
+const TAB_ROOM_SESSION_KEY = 'badam-satti-tab-room-session-v2';
+const SAVED_ROOM_SESSIONS_KEY = 'badam-satti-saved-room-sessions-v2';
+const MAX_SAVED_ROOM_SESSIONS = 8;
+
+function isRoomSession(value) {
+  return Boolean(
+    value &&
+    typeof value.username === 'string' &&
+    value.username.trim().length > 0 &&
+    typeof value.roomCode === 'string' &&
+    /^[A-Z0-9]{6}$/.test(value.roomCode) &&
+    typeof value.sessionToken === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.sessionToken)
+  );
+}
+
+function normalizeRoomSession(value) {
+  if (!isRoomSession(value)) return null;
+  return {
+    username: value.username.trim(),
+    roomCode: value.roomCode,
+    sessionToken: value.sessionToken,
+  };
+}
+
+function parseStoredValue(storage, key) {
+  try {
+    return JSON.parse(storage.getItem(key) || 'null');
+  } catch {
+    return null;
+  }
+}
+
+function sameRoomSession(first, second) {
+  return Boolean(
+    first &&
+    second &&
+    first.roomCode === second.roomCode &&
+    first.username === second.username &&
+    first.sessionToken === second.sessionToken
+  );
+}
+
+function readSavedRoomSessions(localStorage) {
+  const stored = parseStoredValue(localStorage, SAVED_ROOM_SESSIONS_KEY);
+  if (!Array.isArray(stored)) return [];
+
+  return stored
+    .map((entry) => {
+      const session = normalizeRoomSession(entry);
+      return session
+        ? { ...session, updatedAt: Number.isFinite(entry.updatedAt) ? entry.updatedAt : 0 }
+        : null;
+    })
+    .filter(Boolean)
+    .sort((first, second) => second.updatedAt - first.updatedAt);
+}
+
+function writeSavedRoomSessions(localStorage, sessions) {
+  try {
+    if (sessions.length === 0) {
+      localStorage.removeItem(SAVED_ROOM_SESSIONS_KEY);
+      return;
+    }
+    localStorage.setItem(SAVED_ROOM_SESSIONS_KEY, JSON.stringify(sessions.slice(0, MAX_SAVED_ROOM_SESSIONS)));
+  } catch {
+    // The room still works in this tab when browser storage is unavailable.
+  }
+}
+
+export function loadTabRoomSession(sessionStorage = window.sessionStorage) {
+  return normalizeRoomSession(parseStoredValue(sessionStorage, TAB_ROOM_SESSION_KEY));
+}
+
+export function loadMostRecentSavedRoomSession(localStorage = window.localStorage) {
+  const savedSession = readSavedRoomSessions(localStorage)[0];
+  if (savedSession) return normalizeRoomSession(savedSession);
+  return normalizeRoomSession(parseStoredValue(localStorage, LEGACY_ROOM_SESSION_KEY));
+}
+
+export function findSavedRoomSession(
+  roomCode,
+  username,
+  sessionStorage = window.sessionStorage,
+  localStorage = window.localStorage,
+) {
+  const normalizedCode = roomCode.trim().toUpperCase();
+  const normalizedUsername = username.trim();
+  const tabSession = loadTabRoomSession(sessionStorage);
+  if (
+    tabSession?.roomCode === normalizedCode &&
+    tabSession.username === normalizedUsername
+  ) {
+    return tabSession;
+  }
+
+  const savedSession = readSavedRoomSessions(localStorage).find(
+    (session) => session.roomCode === normalizedCode && session.username === normalizedUsername,
+  );
+  if (savedSession) return normalizeRoomSession(savedSession);
+
+  const legacySession = normalizeRoomSession(parseStoredValue(localStorage, LEGACY_ROOM_SESSION_KEY));
+  return legacySession?.roomCode === normalizedCode && legacySession.username === normalizedUsername
+    ? legacySession
+    : null;
+}
+
+export function findSavedRoomSessionForRoom(
+  roomCode,
+  sessionStorage = window.sessionStorage,
+  localStorage = window.localStorage,
+) {
+  const normalizedCode = roomCode.trim().toUpperCase();
+  const tabSession = loadTabRoomSession(sessionStorage);
+  if (tabSession?.roomCode === normalizedCode) return tabSession;
+
+  const savedSession = readSavedRoomSessions(localStorage).find(
+    (session) => session.roomCode === normalizedCode,
+  );
+  if (savedSession) return normalizeRoomSession(savedSession);
+
+  const legacySession = normalizeRoomSession(parseStoredValue(localStorage, LEGACY_ROOM_SESSION_KEY));
+  return legacySession?.roomCode === normalizedCode ? legacySession : null;
+}
+
+export function saveRoomSession(
+  value,
+  sessionStorage = window.sessionStorage,
+  localStorage = window.localStorage,
+  now = Date.now(),
+) {
+  const session = normalizeRoomSession(value);
+  if (!session) return;
+
+  try {
+    sessionStorage.setItem(TAB_ROOM_SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // The live in-memory session still works when browser storage is unavailable.
+  }
+
+  const savedSessions = readSavedRoomSessions(localStorage)
+    .filter((candidate) => (
+      candidate.roomCode !== session.roomCode || candidate.username !== session.username
+    ));
+  writeSavedRoomSessions(localStorage, [{ ...session, updatedAt: now }, ...savedSessions]);
+
+  try {
+    localStorage.removeItem(LEGACY_ROOM_SESSION_KEY);
+  } catch {
+    // Ignore cleanup failures because the new records are already saved.
+  }
+}
+
+export function clearRoomSession(
+  value,
+  sessionStorage = window.sessionStorage,
+  localStorage = window.localStorage,
+) {
+  const tabSession = loadTabRoomSession(sessionStorage);
+  const session = normalizeRoomSession(value) || tabSession;
+  if (!session) return;
+
+  if (!value || sameRoomSession(tabSession, session)) {
+    try {
+      sessionStorage.removeItem(TAB_ROOM_SESSION_KEY);
+    } catch {
+      // The live in-memory session can still be cleared.
+    }
+  }
+
+  const remainingSessions = readSavedRoomSessions(localStorage)
+    .filter((candidate) => !sameRoomSession(candidate, session));
+  writeSavedRoomSessions(localStorage, remainingSessions);
+
+  const legacySession = normalizeRoomSession(parseStoredValue(localStorage, LEGACY_ROOM_SESSION_KEY));
+  if (sameRoomSession(legacySession, session)) {
+    try {
+      localStorage.removeItem(LEGACY_ROOM_SESSION_KEY);
+    } catch {
+      // Ignore cleanup failures because the active tab state is already cleared.
+    }
+  }
+}
+
+export const roomSessionStorageKeys = {
+  legacy: LEGACY_ROOM_SESSION_KEY,
+  tab: TAB_ROOM_SESSION_KEY,
+  saved: SAVED_ROOM_SESSIONS_KEY,
+};

--- a/client/src/roomSession.test.js
+++ b/client/src/roomSession.test.js
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  clearRoomSession,
+  findSavedRoomSession,
+  loadMostRecentSavedRoomSession,
+  loadTabRoomSession,
+  roomSessionStorageKeys,
+  saveRoomSession,
+} from './roomSession.js';
+
+class MemoryStorage {
+  values = new Map();
+
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, value);
+  }
+
+  removeItem(key) {
+    this.values.delete(key);
+  }
+}
+
+const firstSession = {
+  roomCode: 'ABC123',
+  username: 'First',
+  sessionToken: '11111111-1111-4111-8111-111111111111',
+};
+const secondSession = {
+  roomCode: 'XYZ789',
+  username: 'Second',
+  sessionToken: '22222222-2222-4222-8222-222222222222',
+};
+
+test('each tab keeps its own active room while recovery records keep both rooms', () => {
+  const localStorage = new MemoryStorage();
+  const firstTab = new MemoryStorage();
+  const secondTab = new MemoryStorage();
+
+  saveRoomSession(firstSession, firstTab, localStorage, 10);
+  saveRoomSession(secondSession, secondTab, localStorage, 20);
+
+  assert.deepEqual(loadTabRoomSession(firstTab), firstSession);
+  assert.deepEqual(loadTabRoomSession(secondTab), secondSession);
+  assert.deepEqual(findSavedRoomSession('ABC123', 'First', secondTab, localStorage), firstSession);
+  assert.deepEqual(findSavedRoomSession('XYZ789', 'Second', firstTab, localStorage), secondSession);
+});
+
+test('clearing a stale tab does not clear a newer room in another tab', () => {
+  const localStorage = new MemoryStorage();
+  const staleTab = new MemoryStorage();
+  const currentTab = new MemoryStorage();
+
+  saveRoomSession(firstSession, staleTab, localStorage, 10);
+  saveRoomSession(secondSession, currentTab, localStorage, 20);
+  clearRoomSession(firstSession, staleTab, localStorage);
+
+  assert.equal(loadTabRoomSession(staleTab), null);
+  assert.deepEqual(loadTabRoomSession(currentTab), secondSession);
+  assert.equal(findSavedRoomSession('ABC123', 'First', staleTab, localStorage), null);
+  assert.deepEqual(findSavedRoomSession('XYZ789', 'Second', staleTab, localStorage), secondSession);
+});
+
+test('a new tab does not automatically take over a saved room from another tab', () => {
+  const localStorage = new MemoryStorage();
+  const firstTab = new MemoryStorage();
+  const newTab = new MemoryStorage();
+
+  saveRoomSession(firstSession, firstTab, localStorage, 10);
+
+  assert.equal(loadTabRoomSession(newTab), null);
+  assert.deepEqual(findSavedRoomSession('ABC123', 'First', newTab, localStorage), firstSession);
+});
+
+test('the old shared session is migrated once for existing players', () => {
+  const localStorage = new MemoryStorage();
+  const tabStorage = new MemoryStorage();
+  localStorage.setItem(roomSessionStorageKeys.legacy, JSON.stringify(firstSession));
+
+  assert.deepEqual(loadMostRecentSavedRoomSession(localStorage), firstSession);
+  saveRoomSession(firstSession, tabStorage, localStorage, 10);
+  assert.deepEqual(loadTabRoomSession(tabStorage), firstSession);
+  assert.equal(localStorage.getItem(roomSessionStorageKeys.legacy), null);
+});

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -126,7 +126,7 @@ export interface SocketEvents {
   turn_passed: (data: { playerName: string; gameState: GameState; automatic?: boolean }) => void;
   turn_duration_changed: (data: { turnDurationSeconds: number; gameState: GameState }) => void;
   game_over: (winner: Winner) => void;
-  game_abandoned: (data: { message: string }) => void;
+  game_abandoned: (data: { message: string; recoveryFailure?: boolean }) => void;
   cards_redistributed: (data: { message: string }) => void;
   not_enough_players: (data: { message: string; gameState: GameState }) => void;
   round_continued: (data: { gameState: GameState }) => void;

--- a/server/index.js
+++ b/server/index.js
@@ -177,6 +177,16 @@ function emitSocketError(socket, code, message) {
   socket.emit("error", { code, message });
 }
 
+function emitEndedRoomRecovery(socket) {
+  emitSocketError(socket, "ROOM_NOT_FOUND", "Room not found");
+  // Clients that were already open before the tab recovery fix understand
+  // game_abandoned, so this second event also releases them from stale rooms.
+  socket.emit("game_abandoned", {
+    message: "This game has ended.",
+    recoveryFailure: true,
+  });
+}
+
 // Room validation and restoration utility
 async function ensureRoomExists(roomCode) {
   // If room exists in memory, return it
@@ -1001,7 +1011,7 @@ io.on("connection", (socket) => {
 
       const room = await ensureRoomExists(cleanRoomCode);
       if (!room) {
-        emitSocketError(socket, "ROOM_NOT_FOUND", "Room not found");
+        emitEndedRoomRecovery(socket);
         return;
       }
 
@@ -1450,13 +1460,18 @@ io.on("connection", (socket) => {
   socket.on("get_state", async () => {
     try {
       if (!currentRoom) {
-        socket.emit("error", "Not in a valid room");
+        emitSocketError(socket, "RECONNECT_UNAVAILABLE", "Your room session is no longer available");
         return;
       }
 
       const room = await ensureRoomExists(currentRoom);
       if (!room) {
-        socket.emit("error", "Not in a valid room");
+        emitEndedRoomRecovery(socket);
+        return;
+      }
+
+      if (!room.players.some((player) => player.id === socket.id)) {
+        emitSocketError(socket, "RECONNECT_UNAVAILABLE", "Your room session is no longer available");
         return;
       }
 

--- a/server/test/socket.e2e.test.js
+++ b/server/test/socket.e2e.test.js
@@ -164,6 +164,26 @@ async function joinRoom(socket, roomCode, username) {
   return joined;
 }
 
+test('room state checks return codes that distinguish ended rooms from expired seats', async (t) => {
+  const { baseUrl } = await startServer(t);
+  const client = await connectClient(baseUrl);
+  t.after(() => client.close());
+
+  const noSeatError = once(client, 'error');
+  client.emit('get_state');
+  assert.equal((await noSeatError).code, 'RECONNECT_UNAVAILABLE');
+
+  const missingRoomError = once(client, 'error');
+  const endedRoom = new Promise((resolve) => client.once('game_abandoned', resolve));
+  client.emit('reconnect_to_room', {
+    roomCode: 'ZZZZZZ',
+    username: 'Old Tab',
+    sessionToken: '00000000-0000-4000-8000-000000000000',
+  });
+  assert.equal((await missingRoomError).code, 'ROOM_NOT_FOUND');
+  assert.equal((await endedRoom).message, 'This game has ended.');
+});
+
 test('explicit waiting-room leave removes the player immediately', async (t) => {
   const { baseUrl } = await startServer(t);
   const host = await connectClient(baseUrl);


### PR DESCRIPTION
## What changed

The active room is now stored separately for each browser tab. Saved recovery records are kept per room, so an older tab cannot replace or clear a newer game.

Returning tabs check the server for current state. Ended rooms return to the menu with a clear message and no recovery error dialog. A saved game can still be opened through the optional Continue room action.

The server also releases clients that were already open before this fix when their room has ended. Updated service workers reload an open client once so future releases do not leave old application code running.

## Why

One shared local storage record was used by every tab. An old room could therefore block a new game, overwrite its recovery token, or require the player to press Leave room after the old room had already ended.

## Checks

* Client unit tests passed.
* Client lint passed.
* Production build passed.
* All 39 server tests passed.
* All 8 focused room recovery browser tests passed across four device profiles.
* The full Playwright suite passed with 34 passes and 2 expected profile skips.